### PR TITLE
Fix: error about missing purpose string and entitlement

### DIFF
--- a/flashlist_flutter/ios/Runner/Info.plist
+++ b/flashlist_flutter/ios/Runner/Info.plist
@@ -47,5 +47,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>This app may require access to the photo library for image upload functionality.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>This app requires access to save images to your photo library.</string>
+
 </dict>
 </plist>


### PR DESCRIPTION
ITMS-90683: Missing purpose string in Info.plist
ITMS-90078: Missing potentially required entitlement

should be fixed by that